### PR TITLE
Tcp parent monitor

### DIFF
--- a/bigip/resource_bigip_ltm_monitor.go
+++ b/bigip/resource_bigip_ltm_monitor.go
@@ -208,7 +208,7 @@ func resourceBigipLtmMonitorDelete(d *schema.ResourceData, meta interface{}) err
 func validateParent(v interface{}, k string) ([]string, []error) {
 	p := v.(string)
 
-	if p == "http" || p == "https" || p == "icmp" || p == "gateway-icmp" {
+	if p == "http" || p == "https" || p == "icmp" || p == "gateway-icmp" || p == "tcp" {
 		return nil, nil
 	}
 

--- a/bigip/resource_bigip_ltm_monitor.go
+++ b/bigip/resource_bigip_ltm_monitor.go
@@ -212,5 +212,5 @@ func validateParent(v interface{}, k string) ([]string, []error) {
 		return nil, nil
 	}
 
-	return nil, []error{fmt.Errorf("parent must be one of http, https, icmp or gateway-icmp")}
+	return nil, []error{fmt.Errorf("parent must be one of http, https, icmp, gateway-icmp, or tcp")}
 }


### PR DESCRIPTION
Currently specifying `tcp` as the `parent` in the `resource_bigip_monitor` fails with this error:

```
Errors:

  * bigip_ltm_monitor.monitor: parent must be one of http, https, icmp or gateway-icmp
```

This small change allows the usage of `tcp` as the `parent.`
