### PR TITLE
check if we have profiles before attempting to process them

### DIFF
--- a/bigip/resource_bigip_ltm_virtual_server.go
+++ b/bigip/resource_bigip_ltm_virtual_server.go
@@ -179,29 +179,31 @@ func resourceBigipLtmVirtualServerRead(d *schema.ResourceData, meta interface{})
 		return err
 	}
 
-	profile_names := schema.NewSet(schema.HashString, make([]interface{}, 0, len(profiles.Profiles)))
-	client_profile_names := schema.NewSet(schema.HashString, make([]interface{}, 0, len(profiles.Profiles)))
-	server_profile_names := schema.NewSet(schema.HashString, make([]interface{}, 0, len(profiles.Profiles)))
-	for _, profile := range profiles.Profiles {
-		switch profile.Context {
-		case bigip.CONTEXT_CLIENT:
-			client_profile_names.Add(profile.FullPath)
-			break
-		case bigip.CONTEXT_SERVER:
-			server_profile_names.Add(profile.FullPath)
-			break
-		default:
-			profile_names.Add(profile.FullPath)
+	if profiles != nil && len(profiles.Profiles) > 0 {
+		profile_names := schema.NewSet(schema.HashString, make([]interface{}, 0, len(profiles.Profiles)))
+		client_profile_names := schema.NewSet(schema.HashString, make([]interface{}, 0, len(profiles.Profiles)))
+		server_profile_names := schema.NewSet(schema.HashString, make([]interface{}, 0, len(profiles.Profiles)))
+		for _, profile := range profiles.Profiles {
+			switch profile.Context {
+			case bigip.CONTEXT_CLIENT:
+				client_profile_names.Add(profile.FullPath)
+				break
+			case bigip.CONTEXT_SERVER:
+				server_profile_names.Add(profile.FullPath)
+				break
+			default:
+				profile_names.Add(profile.FullPath)
+			}
 		}
-	}
-	if profile_names.Len() > 0 {
-		d.Set("profiles", profile_names)
-	}
-	if client_profile_names.Len() > 0 {
-		d.Set("client_profiles", client_profile_names)
-	}
-	if server_profile_names.Len() > 0 {
-		d.Set("server_profiles", server_profile_names)
+		if profile_names.Len() > 0 {
+			d.Set("profiles", profile_names)
+		}
+		if client_profile_names.Len() > 0 {
+			d.Set("client_profiles", client_profile_names)
+		}
+		if server_profile_names.Len() > 0 {
+			d.Set("server_profiles", server_profile_names)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
Addresses Issue #29.

However; it doesn't follow the suggested pattern.  I wasn't able to make that same pattern work, b/c as i saw it, `GetOk` wouldn't work b/c the values weren't yet in memory.

I opted for this check, where we evaluate that profiles is not nil, and that profiles.Profiles is > 0.

Constructive criticism welcomed. :)
